### PR TITLE
ops: staging log rotation + live-tail defaults

### DIFF
--- a/.scratch/prod-deploy-2026-05/PRD.md
+++ b/.scratch/prod-deploy-2026-05/PRD.md
@@ -1,0 +1,96 @@
+# Prod deploy event — 2026-05-27 (develop → deploy)
+
+## Summary
+
+Bring prod up to current `develop` state. Prod was last deployed on 2026-04-24 (`065460b push to production checkpoint`) — 5 weeks behind. Apply 20 database migrations (23 → 42), provision two new S3 buckets, populate ~15 new env vars, run 3 backfill scripts in sequence.
+
+**RDS prod cutover is a separate event** — see `.scratch/rds-prod-migration/` — and is gated on staging RDS validation closing cleanly (~2026-06-10). This deploy keeps prod's Docker postgres setup unchanged at the connection layer; the new code paths are SSL-aware but `DB_SSL_MODE` stays unset, so behavior falls through to the legacy heuristic.
+
+## Scope
+
+**In scope:**
+- Merge `origin/develop` into `origin/deploy` (force-push; project's existing workflow)
+- Apply Aerich migrations 23-42 on prod Docker postgres via `aerich upgrade` at container startup
+- Create `voltlync-invoices-prod` + `voltlync-firmware-prod` S3 buckets with appropriate CORS + IAM
+- Populate ~15 new env vars in `/home/ec2-user/ocpp-server/.env.prod`
+- Run 3 backfill scripts: `backfill_gst_schema.py`, `backfill_below_threshold.py`, `reconcile_wallet_balance.py`
+- Smoke test the user-visible features that shipped in this batch
+- 24-48h observation window before declaring done
+
+**Out of scope:**
+- **RDS prod provisioning + cutover** — separate event, gated on staging validation
+- New product features beyond what's already on `develop`
+- Touching `main` (this deploy is `develop → deploy`)
+
+## Risk shape
+
+| Component | Risk | Mitigation |
+|---|---|---|
+| 20 sequential migrations | Medium — failures roll back per migration, not as a unit | Pre-deploy backup. Watch logs during `aerich upgrade`. Migration 33 (wallet ledger) is the highest-risk one — has built-in `RAISE NOTICE` output so we'll see drift normalization counts. |
+| Mega-commit `4dc6176 "cutover mid"` bundles 5+ unrelated features | Code already in staging since 2026-05-26 with no regressions | Staging signal is strong enough; treat this as the validation |
+| S3 bucket misconfig (CORS, IAM) | High — invoice PDFs would fail to upload and fetch | Test with manual PUT/GET via aws cli before deploy; verify CORS policy from a browser fetch |
+| Missing env var (especially `VOLTLYNC_GSTIN`) | Silent degradation — invoices skip generation | Pre-deploy checklist; explicit grep on `.env.prod` for all new vars before triggering deploy |
+| Backfill script bugs | Data corruption if `--apply` runs on bad input | All three scripts default to dry-run. `--apply` is opt-in. Review dry-run output before commit. |
+| Backend image rebuild includes the New Relic agent bump (10.6.0 → 13.0.1) | Low — verified on staging since 2026-05-26 with no issues | None needed |
+
+## Decisions locked
+
+| # | Decision | Why |
+|---|---|---|
+| 1 | Code deploy this session; **RDS prod cutover deferred** | Bundling them doubles rollback complexity. Staging RDS validation is still in its first day of a 14-day window. |
+| 2 | Force-push merge via `make prod-push` (project's existing pattern) | Matches established workflow. No merge-commit ceremony. |
+| 3 | Backfills run in dry-run mode first, then `--apply` after human review | All 3 scripts support this. Skipping dry-run is the path to data corruption. |
+| 4 | `RAZORPAY_ROUTE_ENABLED=false`, `WALLET_SETTLEMENT_ENABLED=false` for first deploy | These flip on franchisee payouts. Don't activate at the same time as the migration train — separate change after this deploy stabilizes. |
+| 5 | Pre-deploy `pg_dump` is the rollback artifact | Same pattern as the staging RDS cutover. Lives on EC2 in `backups/`. |
+| 6 | Frontend Sentry/NR Browser env vars are deferred-optional | App works without them; degraded observability only. Don't block the deploy for procurement. |
+
+## Phases
+
+| Phase | Issue | Approx time | Blocks next? |
+|---|---|---|---|
+| 0 — S3 buckets + IAM | `01-create-prod-s3-buckets.md` | 30 min | Yes (env vars reference them) |
+| 0 — Env var procurement + update | `02-populate-prod-env-vars.md` | 30 min – 2 hr (depends on procurement) | Yes (deploy reads these) |
+| 0 — Pre-deploy backup | `03-prod-pg-dump-backup.md` | 5 min | Yes (rollback safety net) |
+| 1 — Code deploy + migrations | `04-merge-and-deploy.md` | 15-30 min downtime | Yes |
+| 1 — Verify backend healthy | `05-post-deploy-verification.md` | 10 min | Yes |
+| 2 — GST schema backfill | `06-backfill-gst-schema.md` | 20 min | Yes (touches invoice rows) |
+| 2 — Below-threshold backfill | `07-backfill-below-threshold.md` | 10 min | No (orthogonal) |
+| 2 — Wallet reconcile validation | `08-reconcile-wallet-balance.md` | 10 min | No (read-only) |
+| 3 — Smoke tests + observation | `09-post-deploy-smoke-tests.md` | 24-48h passive | — |
+
+## Rollback paths
+
+| Failure point | Rollback strategy |
+|---|---|
+| S3 bucket creation fails | Stop. No prod impact yet. |
+| Env var update breaks `.env.prod` parsing | `cp .env.prod.pre-deploy-2026-05-27 .env.prod`. Restart only affects already-running container. |
+| `make prod-deploy` fails during `aerich upgrade` (most likely on migration 33) | DO NOT re-run. Investigate the specific failure. Possible: restore from pre-deploy `pg_dump`, revert deploy branch to `065460b`, re-deploy old image. ~30 min total. |
+| Backend starts but a specific endpoint is broken | Revert just the code: `git push origin 065460b:deploy --force` then `make prod-deploy` again. Postgres schema stays new (migrations are forward-only). Re-test. |
+| Backfill `--apply` writes wrong data | If caught quickly: restore affected rows from pre-deploy `pg_dump`. If caught late: case-by-case repair. Dry-run review is the upstream guard. |
+| Observation phase surfaces serious issue | Roll code back (as above). If the issue is migration-induced and code-only revert isn't enough, this becomes a major incident. |
+
+## Cost impact
+
+| Item | Approx monthly (USD) |
+|---|---|
+| S3 `voltlync-invoices-prod` (PDFs, 7-year retention) | ~$1–5 first year, growing |
+| S3 `voltlync-firmware-prod` (firmware binaries) | ~$1–2 |
+| NR / Sentry already paid | $0 marginal |
+| Migration / backfill execution | $0 |
+| **Total new** | **~$2-7/mo first year** |
+
+(RDS cost is a separate event — not included here.)
+
+## Issues
+
+Detailed runbooks in `issues/`:
+
+- `01-create-prod-s3-buckets.md` — buckets, CORS, IAM, lifecycle policies
+- `02-populate-prod-env-vars.md` — checklist of every var, where to procure each
+- `03-prod-pg-dump-backup.md` — rollback artifact
+- `04-merge-and-deploy.md` — the actual deploy event
+- `05-post-deploy-verification.md` — mechanical health checks + migration verification
+- `06-backfill-gst-schema.md` — GST invoice backfill with dry-run gate
+- `07-backfill-below-threshold.md` — stuck PENDING settlement entries
+- `08-reconcile-wallet-balance.md` — read-only wallet ledger sanity check
+- `09-post-deploy-smoke-tests.md` — user-flow verification + 24h observation

--- a/.scratch/prod-deploy-2026-05/issues/01-create-prod-s3-buckets.md
+++ b/.scratch/prod-deploy-2026-05/issues/01-create-prod-s3-buckets.md
@@ -1,0 +1,202 @@
+Status: ready-for-human
+
+# Create prod S3 buckets for invoices + firmware
+
+## What to build
+
+Two S3 buckets in `ap-south-1` (Mumbai) under the `voltlync` AWS profile:
+
+1. **`voltlync-invoices-prod`** — GST invoice PDFs
+2. **`voltlync-firmware-prod`** — firmware binary files
+
+Each needs server-side encryption, lifecycle policy, IAM access for the prod EC2 instance role, and (for invoices only) a CORS policy permitting cross-origin GET from `https://app.voltlync.com`.
+
+Both buckets are referenced from the new env vars in issue 02 (`AWS_S3_INVOICE_BUCKET`, `AWS_S3_FIRMWARE_BUCKET`). The backend silently falls back to no-S3 behavior when the env var is empty — so creation needs to happen before env update so we're not stuck in degraded mode.
+
+## Why this approach over alternatives
+
+| Alternative | Reason rejected |
+|---|---|
+| Single bucket with `/invoices/` and `/firmware/` prefixes | Different retention requirements (invoices 7y for GST compliance, firmware ~1y). Different CORS needs. Separating cleanly avoids policy contortions. |
+| Skip CORS on the invoice bucket | Frontend fetches PDF blobs cross-origin via presigned URLs. Without CORS the browser rejects the redirected response — see `feedback_s3_cors_for_pdf_fetch` memory. Burned us once already. |
+| Public bucket with no IAM tightening | Invoices contain customer GSTIN + amounts — PII-adjacent. Private bucket with presigned URL access only. |
+
+## What to do
+
+### 1. Create the invoices bucket
+
+```bash
+aws s3api create-bucket \
+  --profile voltlync \
+  --bucket voltlync-invoices-prod \
+  --region ap-south-1 \
+  --create-bucket-configuration LocationConstraint=ap-south-1
+
+aws s3api put-bucket-encryption \
+  --profile voltlync \
+  --bucket voltlync-invoices-prod \
+  --server-side-encryption-configuration '{
+    "Rules": [{
+      "ApplyServerSideEncryptionByDefault": {"SSEAlgorithm": "AES256"},
+      "BucketKeyEnabled": true
+    }]
+  }'
+
+aws s3api put-public-access-block \
+  --profile voltlync \
+  --bucket voltlync-invoices-prod \
+  --public-access-block-configuration \
+    BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true
+
+# CORS for cross-origin PDF fetch from app.voltlync.com.
+# Per feedback_s3_cors_for_pdf_fetch — required for the admin GST invoice viewer.
+aws s3api put-bucket-cors \
+  --profile voltlync \
+  --bucket voltlync-invoices-prod \
+  --cors-configuration '{
+    "CORSRules": [{
+      "AllowedHeaders": ["*"],
+      "AllowedMethods": ["GET", "HEAD"],
+      "AllowedOrigins": ["https://app.voltlync.com"],
+      "ExposeHeaders": ["ETag", "Content-Length", "Content-Type"],
+      "MaxAgeSeconds": 3600
+    }]
+  }'
+```
+
+Lifecycle: 7-year retention for GST compliance, transition older objects to Glacier Instant Retrieval after 90 days to save cost:
+
+```bash
+aws s3api put-bucket-lifecycle-configuration \
+  --profile voltlync \
+  --bucket voltlync-invoices-prod \
+  --lifecycle-configuration '{
+    "Rules": [{
+      "ID": "invoices-retention",
+      "Status": "Enabled",
+      "Filter": {},
+      "Transitions": [{
+        "Days": 90,
+        "StorageClass": "GLACIER_IR"
+      }],
+      "Expiration": {"Days": 2555}
+    }]
+  }'
+```
+
+### 2. Create the firmware bucket
+
+```bash
+aws s3api create-bucket \
+  --profile voltlync \
+  --bucket voltlync-firmware-prod \
+  --region ap-south-1 \
+  --create-bucket-configuration LocationConstraint=ap-south-1
+
+aws s3api put-bucket-encryption \
+  --profile voltlync \
+  --bucket voltlync-firmware-prod \
+  --server-side-encryption-configuration '{
+    "Rules": [{
+      "ApplyServerSideEncryptionByDefault": {"SSEAlgorithm": "AES256"},
+      "BucketKeyEnabled": true
+    }]
+  }'
+
+aws s3api put-public-access-block \
+  --profile voltlync \
+  --bucket voltlync-firmware-prod \
+  --public-access-block-configuration \
+    BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true
+
+# No CORS — chargers download firmware via short presigned URLs server-side.
+# Lifecycle: 365-day retention for firmware (well past any device upgrade window).
+aws s3api put-bucket-lifecycle-configuration \
+  --profile voltlync \
+  --bucket voltlync-firmware-prod \
+  --lifecycle-configuration '{
+    "Rules": [{
+      "ID": "firmware-retention",
+      "Status": "Enabled",
+      "Filter": {},
+      "Expiration": {"Days": 365}
+    }]
+  }'
+```
+
+### 3. Verify prod EC2 instance role can access both buckets
+
+First identify the prod instance profile:
+
+```bash
+aws ec2 describe-instances \
+  --profile voltlync \
+  --instance-ids i-0df24c96c4d5e890a \
+  --query 'Reservations[].Instances[].IamInstanceProfile' --output json
+```
+
+Take the role name from the returned ARN. Then attach an inline policy granting S3 access (replace `<ROLE_NAME>`):
+
+```bash
+aws iam put-role-policy \
+  --profile voltlync \
+  --role-name <ROLE_NAME> \
+  --policy-name voltlync-prod-s3-access \
+  --policy-document '{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": ["s3:PutObject", "s3:GetObject", "s3:DeleteObject"],
+        "Resource": [
+          "arn:aws:s3:::voltlync-invoices-prod/*",
+          "arn:aws:s3:::voltlync-firmware-prod/*"
+        ]
+      },
+      {
+        "Effect": "Allow",
+        "Action": ["s3:ListBucket", "s3:GetBucketLocation"],
+        "Resource": [
+          "arn:aws:s3:::voltlync-invoices-prod",
+          "arn:aws:s3:::voltlync-firmware-prod"
+        ]
+      }
+    ]
+  }'
+```
+
+### 4. Validate from prod EC2
+
+```bash
+# From SSM session on prod EC2:
+aws s3 ls s3://voltlync-invoices-prod
+aws s3 ls s3://voltlync-firmware-prod
+
+# Write + read a test object:
+echo "test $(date)" > /tmp/s3-test.txt
+aws s3 cp /tmp/s3-test.txt s3://voltlync-invoices-prod/healthcheck.txt
+aws s3 cp s3://voltlync-invoices-prod/healthcheck.txt -
+aws s3 rm s3://voltlync-invoices-prod/healthcheck.txt
+# Repeat for firmware bucket.
+```
+
+### 5. Validate CORS from a browser
+
+Open https://app.voltlync.com in a browser, then in DevTools console:
+
+```javascript
+fetch('https://voltlync-invoices-prod.s3.ap-south-1.amazonaws.com/', {mode: 'cors'})
+  .then(r => console.log('CORS OK', r.status))
+  .catch(e => console.error('CORS FAIL', e));
+```
+
+Expected: a 403 (the bucket is private — no anonymous list) but the preflight CORS check passes. If you see a CORS error in the console, the policy isn't right.
+
+## Definition of done
+
+- Both buckets exist, encrypted, public access blocked
+- Invoice bucket has CORS allowing `https://app.voltlync.com` GET/HEAD
+- Lifecycle policies configured (invoices 90d → Glacier-IR, 7y expiration; firmware 365d expiration)
+- Prod EC2 role has IAM policy attached granting PUT/GET/DELETE/LIST on both buckets
+- Write + read smoke test from prod EC2 succeeds for both buckets
+- CORS preflight passes from app.voltlync.com origin

--- a/.scratch/prod-deploy-2026-05/issues/02-populate-prod-env-vars.md
+++ b/.scratch/prod-deploy-2026-05/issues/02-populate-prod-env-vars.md
@@ -1,0 +1,128 @@
+Status: ready-for-human
+
+# Procure + populate new env vars in `.env.prod` on prod EC2
+
+## What to build
+
+Add ~15 new env vars to `/home/ec2-user/ocpp-server/.env.prod` on the prod EC2 instance. Some values are deterministic (defaults from `.env.prod.example`). Others require procurement: GSTIN from finance/legal, Sentry+NR keys from those respective consoles.
+
+The deploy in issue 04 reads `.env.prod` via the `--env-file` flag during `docker compose up -d`. Missing-or-empty values trigger silent degradation (no invoices, no frontend telemetry) rather than crash, so the deploy will technically succeed even with gaps. **The goal is to avoid landing in degraded state.**
+
+Backup the existing `.env.prod` to `.env.prod.pre-deploy-2026-05-27` before editing — that's the file we restore on rollback.
+
+## Why this approach over alternatives
+
+| Alternative | Reason rejected |
+|---|---|
+| Update `.env.prod` via PR / git | `.env.prod` is gitignored on purpose — contains live secrets. It lives only on the EC2 host. |
+| Use AWS Secrets Manager / Parameter Store | Same Q3 decision we locked in the RDS migration interview — `.env.staging`/`.env.prod` is the canonical pattern. Don't drift. |
+| Skip the pre-edit backup | Mistyped `.env.prod` can cause container restart-loops. 5 seconds of `cp` makes rollback a 1-step revert. |
+
+## Procurement checklist
+
+Before touching the file, gather these values:
+
+### Backend (REQUIRED — set or features degrade silently)
+
+| Var | Where to get it | Risk if empty |
+|---|---|---|
+| `VOLTLYNC_GSTIN` | Finance/legal — the actual 15-char GSTIN registered to VOLTLYNC PRIVATE LIMITED | **GST invoices skip generation entirely** |
+| `VOLTLYNC_ADDRESS` | Finance/legal — registered business address | Address blank on invoices (regulatory issue) |
+| `VOLTLYNC_BUSINESS_NAME` | Has default `VOLTLYNC PRIVATE LIMITED` — confirm exact name | Default works |
+| `VOLTLYNC_STATE` / `VOLTLYNC_STATE_CODE` | Has defaults `Kerala` / `32` — confirm | Default works for Kerala-registered entity |
+| `AWS_S3_INVOICE_BUCKET` | From issue 01 — `voltlync-invoices-prod` | Invoice PDFs not persisted (lost on restart) |
+| `AWS_S3_FIRMWARE_BUCKET` | From issue 01 — `voltlync-firmware-prod` | Firmware uploads fall back to local disk |
+| `AWS_REGION` | `ap-south-1` | S3 calls fail |
+
+### New Relic APM (backend already on staging; production agent needs license + browser app)
+
+| Var | Where to get it |
+|---|---|
+| `NEW_RELIC_LICENSE_KEY` | NR account → API keys → Ingest License (same one staging uses, can be reused) |
+| `NEW_RELIC_APP_NAME` | Set to `OCPP-Server-Production` (must differ from staging — see CLAUDE.md Env vars section) |
+| `NEW_RELIC_MONITOR_MODE` | `true` |
+| `NEW_RELIC_DISTRIBUTED_TRACING_ENABLED` | `true` |
+| `NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED` | `true` |
+
+### New Relic Browser (NEW — needs a Browser app created for prod)
+
+| Var | How to get it |
+|---|---|
+| `NEXT_PUBLIC_NEW_RELIC_BROWSER_LICENSE_KEY` | NR UI → + Add Data → Browser monitoring → NPM install → name app `VoltLync Frontend - Production` → extract from generated snippet |
+| `NEXT_PUBLIC_NEW_RELIC_APPLICATION_ID` | Same snippet |
+| `NEXT_PUBLIC_NEW_RELIC_ACCOUNT_ID` | Same snippet |
+| `NEXT_PUBLIC_NEW_RELIC_TRUST_KEY` | Same snippet |
+| `NEXT_PUBLIC_NEW_RELIC_AGENT_ID` | Same snippet |
+
+### Sentry — backend + frontend
+
+| Var | Where to get it |
+|---|---|
+| `SENTRY_ENABLED` | `true` |
+| `SENTRY_DSN` | Sentry → ocpp-server prod project → Client Keys (DSN) |
+| `SENTRY_ENVIRONMENT` | `production` |
+| `SENTRY_TRACES_SAMPLE_RATE` | `0.1` (default — 10%) |
+| `SENTRY_PROFILES_SAMPLE_RATE` | `0.1` |
+| `NEXT_PUBLIC_SENTRY_DSN` | Sentry → ocpp-frontend prod project → Client Keys (DSN). NOTE: separate Sentry project from backend |
+| `SENTRY_ORG` | `idofthings` (already documented in `.env.prod.example`) |
+| `SENTRY_PROJECT` | `ocpp-frontend` |
+| `SENTRY_AUTH_TOKEN` | Sentry → Settings → Custom Integrations → create token with `project:releases` + `project:read` scopes. **Build-time only — needed for source map upload during `next build`.** |
+
+### Razorpay payouts (OFF by default — flip on later)
+
+| Var | Recommended |
+|---|---|
+| `RAZORPAY_ROUTE_ENABLED` | `false` for this deploy. Enable in a focused follow-up after the deploy stabilizes. |
+| `WALLET_SETTLEMENT_ENABLED` | `false` — Razorpay hasn't enabled Direct Transfer on the merchant yet |
+| `MINIMUM_TRANSFER_AMOUNT` | `1.00` |
+| `MAX_TRANSFER_RETRIES` | `3` |
+| `FRANCHISEE_PAYOUT_RETRY_INTERVAL_SECONDS` | `600` |
+| `STUCK_PAYOUT_CHECK_INTERVAL_SECONDS` | `3600` |
+| `STUCK_PAYOUT_THRESHOLD_HOURS` | `24` |
+
+### OCPP/server tuning (all optional, but worth setting explicitly)
+
+Per `.env.prod.example` defaults — `ZERO_ENERGY_TIMEOUT_SECONDS=7200`, `SOCKET_GRACE_PERIOD_SECONDS=300`, `MAX_DISCONNECT_RESETS_WITHOUT_PROGRESS=3`, `MAX_RESUME_GAP_SECONDS=900`, `DISCONNECT_SUSPEND_TIMEOUT_SECONDS=180`, `RAZORPAY_INSTANT_REFUND_ENABLED=true`, `FIRMWARE_PUBLIC_BASE_URL=https://app.voltlync.com`, plus the 4 firmware timing vars.
+
+## What to do
+
+### 1. Backup existing `.env.prod`
+
+```bash
+# From SSM session on prod EC2:
+cd /home/ec2-user/ocpp-server
+cp .env.prod .env.prod.pre-deploy-2026-05-27
+ls -lh .env.prod.pre-deploy-2026-05-27
+```
+
+### 2. Append new env vars
+
+Either:
+- Use `nano /home/ec2-user/ocpp-server/.env.prod` interactively and paste the block
+- OR generate the block locally with all procured values and append via `cat >>` in SSM
+
+Recommended structure: append the new block at the END of `.env.prod`, separated by a comment header. This keeps the existing lines untouched and the diff readable.
+
+### 3. Sanity-grep before deploy
+
+```bash
+# Confirm the critical ones are non-empty:
+grep -E "^(VOLTLYNC_GSTIN|AWS_S3_INVOICE_BUCKET|AWS_S3_FIRMWARE_BUCKET|NEW_RELIC_LICENSE_KEY|SENTRY_DSN)=" .env.prod
+# Each line should show value=<non-empty>
+# If any is empty or missing, fix before proceeding to issue 04
+```
+
+### 4. Verify docker-compose parses correctly with new env
+
+```bash
+$(PROD_COMPOSE) config --quiet && echo OK
+```
+
+Should print `OK`. If it complains about an undefined variable, find which one and add it.
+
+## Definition of done
+
+- `.env.prod.pre-deploy-2026-05-27` exists as a backup
+- All REQUIRED vars (above) have non-empty values in `.env.prod`
+- `docker compose -f docker-compose.prod.yml --env-file .env.prod config --quiet` returns 0
+- Procurement of any deferred values (e.g. Sentry frontend if you're skipping it for now) is documented somewhere outside this issue so it doesn't get forgotten

--- a/.scratch/prod-deploy-2026-05/issues/03-prod-pg-dump-backup.md
+++ b/.scratch/prod-deploy-2026-05/issues/03-prod-pg-dump-backup.md
@@ -1,0 +1,92 @@
+Status: ready-for-agent
+
+# Pre-deploy `pg_dump` of prod Docker postgres
+
+## What to build
+
+A single full `pg_dump` of `ocpp_prod_db` from the live Docker postgres container on prod EC2, saved to `/home/ec2-user/ocpp-server/backups/prod_pre_deploy_2026-05-27.sql`. This is the rollback artifact for the entire deploy event — if migrations 23-42 do anything we don't like, or if backfills go wrong, the path back is `psql < this_file`.
+
+No-impact operation. `pg_dump` is a read-only consistent snapshot; takes a few minutes; doesn't block the running backend.
+
+## Why this approach over alternatives
+
+| Alternative | Reason rejected |
+|---|---|
+| Skip the backup; trust forward-only migrations | "Forward-only" doesn't help if a migration writes garbage into existing rows. Real recovery needs a known-good snapshot. |
+| Take an EBS snapshot of the host disk | Crash-consistent only — Postgres recovery on restore takes minutes and may lose recent writes. `pg_dump` is a transaction-consistent logical snapshot. |
+| Stream `pg_dump` directly to S3 | More moving parts. Local file on EC2 root disk is fine for one-off use (file gets deleted ~1 month later). |
+| Use the existing `make prod-backup-db` Makefile target | That works too, but produces a timestamped filename in `backups/`. Using a named file we know is "the pre-deploy artifact" is cleaner. |
+
+## What to do
+
+```bash
+# SSM into prod EC2 first via `make prod-ssm`, then on the host:
+
+cd /home/ec2-user/ocpp-server
+mkdir -p backups
+
+# Read credentials from existing .env.prod (the file we just backed up in issue 02).
+DB_USER=$(grep ^DB_USER= .env.prod | cut -d= -f2-)
+DB_NAME=$(grep ^DB_NAME= .env.prod | cut -d= -f2-)
+
+DUMP=/home/ec2-user/ocpp-server/backups/prod_pre_deploy_2026-05-27.sql
+
+echo "Starting pg_dump at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+sudo docker exec ocpp-postgres-prod pg_dump \
+  -U "$DB_USER" \
+  --no-owner --no-acl --clean --if-exists \
+  "$DB_NAME" > "$DUMP"
+echo "Completed at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+ls -lh "$DUMP"
+echo "Row counts in dump (sanity):"
+grep -c "^COPY" "$DUMP"
+```
+
+Expected: a file in the 50-500 MB range (depends on real prod data). The `grep -c "^COPY"` line should show the count of tables data was dumped from — a positive integer.
+
+## Verification
+
+```bash
+# Confirm dump is readable + has expected sentinel content
+head -10 "$DUMP"
+# Should show pg_dump header lines
+
+tail -3 "$DUMP"
+# Should show: -- PostgreSQL database dump complete
+
+# Check schema completeness — count CREATE TABLE statements
+grep -c "^CREATE TABLE" "$DUMP"
+# Should match the number of tables in the live DB
+```
+
+Optional but recommended: spot-check a critical row count matches dump vs live DB. Example for `gst_invoice`:
+
+```bash
+LIVE_COUNT=$(sudo docker exec ocpp-postgres-prod psql -U "$DB_USER" -d "$DB_NAME" -tAc "SELECT COUNT(*) FROM gst_invoice;")
+DUMP_COUNT=$(grep -A 1000000 "COPY public.gst_invoice " "$DUMP" | sed -n '/^\\\\\\.$/q;p' | wc -l)
+# DUMP_COUNT will be 1 less because the COPY header line isn't a data row
+echo "Live: $LIVE_COUNT  Dump (approx): $DUMP_COUNT"
+```
+
+## What happens to this file
+
+- **Lives on prod EC2 root disk** through the deploy + validation window
+- **Stays around for 30 days post-deploy** as a forensic artifact (manual cleanup after that)
+- **The actual rollback file**, if needed: `psql -U <user> -d <db> < /home/ec2-user/ocpp-server/backups/prod_pre_deploy_2026-05-27.sql`
+
+If you want long-term archive, copy to S3 (the invoices bucket is fine — encryption is on, lifecycle goes to Glacier):
+
+```bash
+aws s3 cp "$DUMP" s3://voltlync-invoices-prod/_internal/db-backups/$(basename "$DUMP")
+```
+
+(The `_internal/` prefix keeps it organized away from real invoice paths.)
+
+## Definition of done
+
+- `prod_pre_deploy_2026-05-27.sql` exists in `/home/ec2-user/ocpp-server/backups/` on prod EC2
+- File is non-empty (≥50 MB) and `pg_dump` output reports no errors
+- `head` and `tail` of the file show expected `pg_dump` sentinels
+- (Optional) Mirror copy uploaded to `s3://voltlync-invoices-prod/_internal/db-backups/`
+- The path is recorded somewhere accessible for the deploy operator (e.g. in the deploy-thread Slack message)

--- a/.scratch/prod-deploy-2026-05/issues/04-merge-and-deploy.md
+++ b/.scratch/prod-deploy-2026-05/issues/04-merge-and-deploy.md
@@ -1,0 +1,165 @@
+Status: ready-for-human
+
+# Merge `develop → deploy` and run `make prod-deploy`
+
+## What to build
+
+The actual deploy event. Force-push `origin/develop` to `origin/deploy`, then run `make prod-deploy` on the prod EC2 host. This triggers a `git fetch && git reset --hard origin/deploy`, then `docker compose up -d --build --force-recreate`, which:
+
+1. Rebuilds the backend image (CA bundle, new Python deps including newrelic 13.0.1, new code)
+2. Rebuilds the frontend image (Sentry source-map upload during build, new pages, etc.)
+3. Recreates all containers
+4. Entrypoint runs `aerich upgrade` → applies migrations 23-42 in sequence against Docker postgres
+5. Uvicorn starts, OCPP WebSocket listener comes up
+6. Healthcheck endpoint goes from `starting` → `healthy`
+
+**Expected downtime**: 5-10 min for backend + frontend rebuild + migration train. Existing OCPP WebSocket sessions disconnect at recreate; chargers reconnect automatically per their normal retry logic.
+
+**This is human-attended.** Migrations 27, 32, 33, 36 are the highest-risk. Watch logs in a separate terminal. Don't queue this on a flight.
+
+## Prerequisites (must all be done)
+
+- [ ] Issue 01 complete — both S3 buckets exist + IAM attached
+- [ ] Issue 02 complete — all REQUIRED env vars set in `.env.prod`
+- [ ] Issue 03 complete — pre-deploy `pg_dump` saved
+- [ ] Free 60 min of attentive operator time
+- [ ] No active high-impact charging sessions (check `/api/admin/transactions?status=RUNNING`)
+- [ ] Maintenance window announced if applicable
+
+## Why this approach over alternatives
+
+| Alternative | Reason rejected |
+|---|---|
+| Tag a release first, then merge | Project doesn't use release tags. Workflow is force-push `origin/develop → origin/deploy`. Don't change the workflow in the middle of a deploy. |
+| Cherry-pick commits rather than full merge | All 8 commits are dependent or thematically related. Splitting adds work and risk. |
+| Blue-green deploy with a second EC2 | Not how this infra is set up. Real fix is RDS prod migration (separate event). |
+| Skip `--force-recreate` to keep containers warm | New env vars and image rebuilds require `--force-recreate` to take effect. Project's standard pattern. |
+
+## What to do
+
+### 1. Local: push develop to deploy
+
+```bash
+# From your laptop, on the develop branch (or after fetching latest):
+git fetch origin
+git checkout develop
+git pull origin develop
+git push origin develop:deploy --force
+# OR equivalently: make prod-push
+```
+
+### 2. SSM into prod EC2
+
+```bash
+make prod-ssm
+```
+
+### 3. On prod EC2: run the deploy
+
+```bash
+cd /home/ec2-user/ocpp-server
+
+# Open backend logs in a SEPARATE SSM session BEFORE running the deploy:
+# In that other window: sudo docker logs ocpp-backend-prod -f --tail=0
+# (After deploy starts, the new container will replace the old one — switch to:
+#  sudo docker logs ocpp-backend-prod -f --tail=200 once the new container is up)
+
+# Trigger the deploy:
+make prod-deploy
+```
+
+What you'll see (rough timeline):
+
+```
+Pulling from origin/deploy...
+git fetch origin
+git reset --hard origin/deploy
+Updated to origin/deploy
+
+[building images — 3-5 min, especially frontend]
+[recreating containers]
+
+# In the backend log window, watch for:
+# - "Waiting for database..." (entrypoint pre-flight; should connect on attempt 1-2)
+# - "Database is ready!"
+# - "Running database migrations..."
+# - Lines per migration: "23_20260429075904_add_kyc_fields", etc.
+# - PARTICULAR attention on migration 33:
+#     "NOTICE:  Migration 33: normalized X CHARGE_DEDUCT rows"
+#     "NOTICE:  Migration 33: captured X adjustment rows"
+#     If these counts look way off, STOP and roll back. Otherwise proceed.
+# - "Migrations completed successfully."
+# - "Starting OCPP Backend..."
+# - "Starting with New Relic APM..." (because NEW_RELIC_MONITOR_MODE=true)
+# - "Database initialized with Tortoise ORM"
+# - "✅ New Relic APM: ENABLED"
+# - "✅ Sentry Error Tracking: ENABLED"
+# - "OCPP Central System API started"
+```
+
+If any migration step shows a Postgres ERROR — STOP. Don't re-run. Go to rollback. See issue 03 for the dump file path.
+
+### 4. Wait for healthy
+
+```bash
+# In an SSM session on the host:
+sudo docker ps --filter name=ocpp-backend-prod --format "table {{.Names}}\\t{{.Status}}"
+# Should show: Up XX seconds (healthy) — note healthcheck has start_period=40s
+
+curl -sf https://app.voltlync.com/health
+# Should return 200 with database + redis both healthy
+```
+
+Total expected time from `make prod-deploy` start to backend `(healthy)`: **5-10 minutes**.
+
+## Rollback procedure
+
+If migrations fail OR backend won't start cleanly:
+
+```bash
+# 1. Stop the broken backend
+sudo docker compose -f docker-compose.prod.yml --env-file .env.prod stop backend
+
+# 2. Restore the pre-deploy DB
+DB_USER=$(grep ^DB_USER= .env.prod | cut -d= -f2-)
+DB_NAME=$(grep ^DB_NAME= .env.prod | cut -d= -f2-)
+DB_PASSWORD=$(grep ^DB_PASSWORD= .env.prod | cut -d= -f2-)
+
+# Drop and recreate the prod DB inside the postgres container
+sudo docker exec ocpp-postgres-prod psql -U "$DB_USER" -d postgres -c "DROP DATABASE IF EXISTS $DB_NAME;"
+sudo docker exec ocpp-postgres-prod psql -U "$DB_USER" -d postgres -c "CREATE DATABASE $DB_NAME OWNER $DB_USER;"
+
+# Restore the pre-deploy dump
+cat /home/ec2-user/ocpp-server/backups/prod_pre_deploy_2026-05-27.sql \
+  | sudo docker exec -i ocpp-postgres-prod psql -U "$DB_USER" -d "$DB_NAME"
+
+# 3. Revert the code on prod
+git push origin 065460b:deploy --force          # FROM YOUR LAPTOP
+# Then on prod EC2:
+make prod-deploy
+# This pulls the old commit + rebuilds with the old image + old migrations are already applied (they match)
+```
+
+Rollback total time: ~30-40 min depending on dump size + rebuild time.
+
+## Verification (the basics — issue 05 has the full check)
+
+- Backend container is up and `(healthy)`
+- `https://app.voltlync.com/health` returns 200 with database + redis healthy
+- `sudo docker logs ocpp-backend-prod 2>&1 | grep -E "Migrations completed|New Relic APM|Database initialized"` shows all three lines
+- No `ERROR` or `FATAL` lines in the last 5 min of logs
+- Aerich version on prod matches what we expect:
+  ```bash
+  sudo docker exec ocpp-backend-prod aerich heads
+  # Should show 42_20260527070319_add_charger_availability.py
+  ```
+
+## Definition of done
+
+- All migrations 23-42 applied (verified via `aerich heads`)
+- Backend container `(healthy)`
+- Health endpoint returns 200
+- No error/fatal log lines since deploy start
+- `OCPP-Server-Production` entity appearing in NR APM with traffic flowing
+- Sentry receiving events at the `production` environment tag
+- Issue 05 (post-deploy verification) ready to start

--- a/.scratch/prod-deploy-2026-05/issues/05-post-deploy-verification.md
+++ b/.scratch/prod-deploy-2026-05/issues/05-post-deploy-verification.md
@@ -1,0 +1,124 @@
+Status: ready-for-agent
+
+# Post-deploy verification — confirm migrations + backend health on prod
+
+## What to build
+
+Mechanical verification that the deploy from issue 04 actually achieved what it claimed. Not user-flow testing (that's issue 09) — this is "did the migrations apply, is the backend connecting to its DB, do the new feature flags read as expected."
+
+If any check fails, STOP and investigate. Do not run backfills (issues 06-08) until everything here is green.
+
+## Why this approach over alternatives
+
+| Alternative | Reason rejected |
+|---|---|
+| Skip mechanical checks, jump to feature smoke tests | Mechanical confirms "the deploy actually happened correctly." Feature tests can pass on partially-broken systems if the broken parts aren't exercised. |
+| Just trust the `make prod-deploy` exit code | The Makefile doesn't gate on `aerich upgrade` success — entrypoint runs migrations and `exec`s uvicorn even if a non-fatal migration error happened. Need to verify explicitly. |
+
+## What to do
+
+This issue is `ready-for-agent` — the agent can drive these checks via SSM. Single SSM batch:
+
+```bash
+# All from a single SSM command for atomic snapshot:
+
+echo "=== 1. Backend container status ==="
+sudo docker ps --filter name=ocpp-backend-prod --format "table {{.Names}}\\t{{.Status}}"
+# Expected: Up XX (healthy)
+
+echo "=== 2. Backend env reflects new deploy ==="
+sudo docker exec ocpp-backend-prod printenv DB_HOST DB_NAME DB_USER NEW_RELIC_APP_NAME SENTRY_ENVIRONMENT \
+  VOLTLYNC_GSTIN AWS_S3_INVOICE_BUCKET AWS_S3_FIRMWARE_BUCKET
+# Expected:
+#   DB_HOST=postgres        ← still Docker postgres
+#   DB_NAME=ocpp_prod_db
+#   DB_USER=ocpp_prod
+#   NEW_RELIC_APP_NAME=OCPP-Server-Production
+#   SENTRY_ENVIRONMENT=production
+#   VOLTLYNC_GSTIN=<non-empty>
+#   AWS_S3_INVOICE_BUCKET=voltlync-invoices-prod
+#   AWS_S3_FIRMWARE_BUCKET=voltlync-firmware-prod
+
+echo "=== 3. Aerich head matches expected ==="
+sudo docker exec ocpp-backend-prod aerich heads
+# Expected exactly: 42_20260527070319_add_charger_availability.py
+
+echo "=== 4. All migrations applied — count check ==="
+DB_USER=$(grep ^DB_USER= /home/ec2-user/ocpp-server/.env.prod | cut -d= -f2-)
+DB_NAME=$(grep ^DB_NAME= /home/ec2-user/ocpp-server/.env.prod | cut -d= -f2-)
+sudo docker exec ocpp-postgres-prod psql -U "$DB_USER" -d "$DB_NAME" -tAc \
+  "SELECT MAX(id), MAX(version) FROM aerich;"
+# Expected: 42 (or whatever max id is) + the 42_... filename
+
+echo "=== 5. Critical new columns exist ==="
+sudo docker exec ocpp-postgres-prod psql -U "$DB_USER" -d "$DB_NAME" -c "
+  SELECT column_name FROM information_schema.columns
+  WHERE table_name='charger' AND column_name='availability';
+"
+# Expected: 1 row, availability
+sudo docker exec ocpp-postgres-prod psql -U "$DB_USER" -d "$DB_NAME" -c "
+  SELECT column_name FROM information_schema.columns
+  WHERE table_name='gst_invoice'
+  AND column_name IN ('place_of_supply_state_code', 'series', 'financial_year', 'gst_rate_percent');
+"
+# Expected: 4 rows
+
+echo "=== 6. wallet.balance column dropped (migration 33) ==="
+sudo docker exec ocpp-postgres-prod psql -U "$DB_USER" -d "$DB_NAME" -c "
+  SELECT column_name FROM information_schema.columns
+  WHERE table_name='wallet' AND column_name='balance';
+"
+# Expected: 0 rows — column has been removed
+
+echo "=== 7. wallet_transaction CHECK constraint is VALID ==="
+sudo docker exec ocpp-postgres-prod psql -U "$DB_USER" -d "$DB_NAME" -c "
+  SELECT conname, convalidated FROM pg_constraint
+  WHERE conname='wallet_transaction_amount_non_negative';
+"
+# Expected: 1 row, convalidated=t
+
+echo "=== 8. No negative CHARGE_DEDUCT rows ==="
+sudo docker exec ocpp-postgres-prod psql -U "$DB_USER" -d "$DB_NAME" -tAc "
+  SELECT COUNT(*) FROM wallet_transaction WHERE type='CHARGE_DEDUCT' AND amount < 0;
+"
+# Expected: 0 — migration 33 should have normalized all of these
+
+echo "=== 9. Recent startup logs ==="
+sudo docker logs ocpp-backend-prod 2>&1 | grep -E "Migrations completed|Database initialized|New Relic APM: ENABLED|Sentry Error Tracking: ENABLED|Starting OCPP" | tail -10
+
+echo "=== 10. Last 60s of error-level logs ==="
+sudo docker logs ocpp-backend-prod --since 60s 2>&1 | grep -iE "fatal|cannot connect|password authentication|ssl error|exception" | head -10
+# Expected: empty (or only benign init warnings)
+
+echo "=== 11. Health endpoint ==="
+curl -sf https://app.voltlync.com/health && echo " HEALTHY" || echo " UNHEALTHY"
+
+echo "=== 12. Live OCPP traffic ==="
+sudo docker logs ocpp-backend-prod --since 30s 2>&1 | grep -iE "Heartbeat|StatusNotification" | wc -l
+# Expected: > 0 — chargers should be reconnecting + sending heartbeats
+```
+
+## Verification interpretation
+
+| Check | Pass criteria | If fails |
+|---|---|---|
+| 1 | Container `healthy` after ~60s | Container restart-loop → check logs for migration error |
+| 2 | All env vars non-empty + correct values | Re-do issue 02; restart backend |
+| 3 | `aerich heads` shows migration 42 filename | Migration train didn't complete — check logs around the broken migration |
+| 4 | Max aerich id ≥ 42 | Same as 3 |
+| 5 | All listed columns exist | Migrations didn't apply — STOP, investigate, possibly roll back |
+| 6 | 0 rows (column gone) | Migration 33 didn't apply — major problem |
+| 7 | `convalidated = t` | Migration 33's redemption step failed — there are still negative CHARGE_DEDUCT amounts somewhere |
+| 8 | 0 negative rows | Same — migration 33 normalization failed |
+| 9 | All 5 log lines present | Backend startup incomplete — investigate |
+| 10 | No matches | If there are matches, read them carefully — might be benign warnings or real problems |
+| 11 | 200 HEALTHY | Backend not serving HTTP — check nginx and backend logs |
+| 12 | > 0 in 30s | Chargers haven't reconnected yet (give it 60s) OR WebSocket layer is broken |
+
+## Definition of done
+
+- All 12 checks pass
+- Verified by SSM output stored somewhere accessible (paste into the deploy thread)
+- Aerich head matches `42_20260527070319_add_charger_availability.py`
+- Wallet ledger structural changes (migration 33) verified — no negative CHARGE_DEDUCT rows, constraint VALID, balance column gone
+- Issues 06, 07, 08 (backfills) can now proceed

--- a/.scratch/prod-deploy-2026-05/issues/06-backfill-gst-schema.md
+++ b/.scratch/prod-deploy-2026-05/issues/06-backfill-gst-schema.md
@@ -1,0 +1,91 @@
+Status: ready-for-human
+
+# Run `backfill_gst_schema.py` on prod
+
+## What to build
+
+Run the GST schema backfill script that completes what migrations 27 + 28 couldn't do (because they can't read env vars or do multi-table joins). The script handles 12 categories of fields on the `gst_invoice` table: place-of-supply state code (via station join), transaction_amount, energy_taxable_value, gateway_charges, GST splits, HSN code corrections, supplier identity (from env vars), tariff HSN code.
+
+**Default: dry-run.** Apply only after reviewing the dry-run output.
+
+## Prerequisites
+
+- [ ] Issue 05 complete — deploy verified, migrations applied
+- [ ] `VOLTLYNC_GSTIN` is non-empty in `.env.prod` (script uses this for supplier_gstin field)
+- [ ] `VOLTLYNC_ADDRESS` is non-empty (used for supplier_address)
+- [ ] An attentive operator with prod write authority — `--apply` modifies invoice rows
+
+## Why this approach over alternatives
+
+| Alternative | Reason rejected |
+|---|---|
+| Skip the backfill — accept the partial state | `supplier_gstin` is required for GST invoices to be legally valid. Without backfill, old invoices have NULL there and can't be reissued or audited. |
+| Run `--apply` without dry-run | Modifies invoice rows in place. Even though it's idempotent (re-runnable), getting bad data in is harder to recover from than reviewing first. |
+| Backfill via direct SQL | Script handles multi-table joins (txn → charger → station for state code) that are tedious to express inline. Use the script. |
+
+## What to do
+
+### 1. Dry-run
+
+```bash
+# SSM into prod EC2:
+sudo docker exec ocpp-backend-prod python -m scripts.backfill_gst_schema --dry-run 2>&1 | tee /tmp/gst-backfill-dryrun.log
+```
+
+Read the output. Expected to show:
+- Number of `gst_invoice` rows to update per field
+- Sample rows showing what values will be set
+- Any rows it can't process (e.g. invoice with no linked transaction) — these need manual investigation
+
+### 2. Sanity-review the dry-run
+
+- Does the count of rows match what you'd expect for prod's invoice history?
+- Do the supplier_gstin / supplier_address values in the output match what's in `.env.prod`?
+- Are there any "skipping row X — no linked txn" warnings? Note those for follow-up.
+- HSN code corrections show `previous_value=null → new_value='996749'` (or similar)
+
+If anything looks wrong, STOP and investigate before --apply.
+
+### 3. Apply
+
+```bash
+sudo docker exec ocpp-backend-prod python -m scripts.backfill_gst_schema 2>&1 | tee /tmp/gst-backfill-apply.log
+```
+
+(The script takes no flag for apply — `--dry-run` is the opt-in dry mode; running without it commits.)
+
+Look for the summary line at the end: how many rows updated per field.
+
+### 4. Verify
+
+```bash
+DB_USER=$(grep ^DB_USER= /home/ec2-user/ocpp-server/.env.prod | cut -d= -f2-)
+DB_NAME=$(grep ^DB_NAME= /home/ec2-user/ocpp-server/.env.prod | cut -d= -f2-)
+
+# Spot-check: pick the most recent invoice and verify the new fields are populated
+sudo docker exec ocpp-postgres-prod psql -U "$DB_USER" -d "$DB_NAME" -x -c "
+  SELECT id, invoice_number, supplier_gstin, supplier_name, place_of_supply_state_code,
+         series, financial_year, hsn_sac_code, gst_rate_percent
+  FROM gst_invoice ORDER BY id DESC LIMIT 1;
+"
+
+# Aggregate: count of rows still missing the critical fields (should be 0 or near-0)
+sudo docker exec ocpp-postgres-prod psql -U "$DB_USER" -d "$DB_NAME" -c "
+  SELECT
+    COUNT(*) FILTER (WHERE supplier_gstin IS NULL OR supplier_gstin = '') AS missing_supplier_gstin,
+    COUNT(*) FILTER (WHERE hsn_sac_code IS NULL) AS missing_hsn,
+    COUNT(*) FILTER (WHERE place_of_supply_state_code IS NULL) AS missing_state_code
+  FROM gst_invoice;
+"
+```
+
+Expected: zero or very few missing values. Some rows might legitimately not have a state code (invoices generated before the station data was populated) — those go in the manual-follow-up bucket.
+
+## Definition of done
+
+- Dry-run completed cleanly + output reviewed
+- Apply completed cleanly + summary line shows expected row counts
+- Spot-check verifies fields populated correctly on a sample invoice
+- Aggregate check shows zero or near-zero missing values for critical fields
+- Any manual-follow-up rows from the dry-run are documented somewhere outside this issue
+- `/tmp/gst-backfill-apply.log` captured for forensics

--- a/.scratch/prod-deploy-2026-05/issues/07-backfill-below-threshold.md
+++ b/.scratch/prod-deploy-2026-05/issues/07-backfill-below-threshold.md
@@ -1,0 +1,81 @@
+Status: ready-for-human
+
+# Run `backfill_below_threshold.py` on prod
+
+## What to build
+
+One-shot backfill that flips stuck `PENDING` `commission_ledger_entry` rows with sub-floor `franchisee_payout` (`< MINIMUM_TRANSFER_AMOUNT`, default ₹1.00) into the new terminal status `BELOW_THRESHOLD`. These entries were created before the `BELOW_THRESHOLD` state existed in the enum (migration 25), so they got stuck as `PENDING` and the retry sweep silently ignored them.
+
+Same pattern as staging — we ran this same script on staging to clear 5 sub-paise entries.
+
+**Default: dry-run.** Apply with `--apply` after review.
+
+## Prerequisites
+
+- [ ] Issue 05 complete — deploy verified
+- [ ] Migration 25 (`add_below_threshold_settlement_status`) applied (confirmed in issue 05 check #5)
+- [ ] `MINIMUM_TRANSFER_AMOUNT` env var present (defaults to `1.00`)
+
+## Why this approach over alternatives
+
+| Alternative | Reason rejected |
+|---|---|
+| Leave the PENDING entries alone | They'll trigger the stuck-payout Sentry alert (which is configured to fire after `STUCK_PAYOUT_THRESHOLD_HOURS=24`). Not blocking, just noise — but it's noise that masks real stuck-payout incidents. |
+| Manual `UPDATE` SQL | Loses the script's safety check (`amount < MIN`). Scripted is auditable + idempotent. |
+| Skip on prod, only run on staging | The staging entries we cleared were 5 sub-paise rows. Prod likely has its own backlog. |
+
+## What to do
+
+### 1. Dry-run
+
+```bash
+sudo docker exec ocpp-backend-prod python scripts/backfill_below_threshold.py 2>&1 | tee /tmp/below-threshold-dryrun.log
+```
+
+Read the output. Expected to show:
+- Number of stuck PENDING entries with `payout < ₹1.00`
+- Per-row info: id, franchisee_id, payout amount, age
+- Total row count to be flipped
+
+If the count is zero — there's nothing to do, the issue is `completed` immediately.
+
+If the count is non-zero — review individual rows for sanity. Real sub-floor payouts have tiny amounts (paise-range); anything suspicious (e.g. payout = ₹50, why is this PENDING?) needs investigation before --apply.
+
+### 2. Apply
+
+```bash
+sudo docker exec ocpp-backend-prod python scripts/backfill_below_threshold.py --apply 2>&1 | tee /tmp/below-threshold-apply.log
+```
+
+Expected output: confirmation of N rows flipped to BELOW_THRESHOLD.
+
+### 3. Verify
+
+```bash
+DB_USER=$(grep ^DB_USER= /home/ec2-user/ocpp-server/.env.prod | cut -d= -f2-)
+DB_NAME=$(grep ^DB_NAME= /home/ec2-user/ocpp-server/.env.prod | cut -d= -f2-)
+
+# Confirm no remaining PENDING sub-floor entries
+sudo docker exec ocpp-postgres-prod psql -U "$DB_USER" -d "$DB_NAME" -c "
+  SELECT COUNT(*) AS still_stuck
+  FROM commission_ledger_entry
+  WHERE settlement_status='PENDING' AND franchisee_payout < 1.00;
+"
+# Expected: 0
+
+# Spot-check the new BELOW_THRESHOLD rows
+sudo docker exec ocpp-postgres-prod psql -U "$DB_USER" -d "$DB_NAME" -c "
+  SELECT id, franchisee_id, franchisee_payout, settlement_status
+  FROM commission_ledger_entry
+  WHERE settlement_status='BELOW_THRESHOLD'
+  ORDER BY id DESC LIMIT 10;
+"
+```
+
+## Definition of done
+
+- Dry-run completed + output reviewed
+- (If non-zero count) `--apply` completed cleanly
+- Verification query returns 0 stuck-PENDING sub-floor entries
+- (If non-zero count) Spot-check shows the flipped rows are in `BELOW_THRESHOLD`
+- The stuck-payout Sentry alert should NOT fire on the next sweep for these entries

--- a/.scratch/prod-deploy-2026-05/issues/08-reconcile-wallet-balance.md
+++ b/.scratch/prod-deploy-2026-05/issues/08-reconcile-wallet-balance.md
@@ -1,0 +1,80 @@
+Status: ready-for-agent
+
+# Run `reconcile_wallet_balance.py` as validation (read-only)
+
+## What to build
+
+Read-only sanity check that the event-sourced wallet ledger (post migration 33) sums correctly. The script compares the derived balance (`SUM(amount) per wallet_id, signed by type`) against… well, against itself in different ways — looking for inconsistencies like negative derived balances, orphaned transactions, mismatched type+sign combinations.
+
+This is **not** a backfill — migration 33 already normalized CHARGE_DEDUCT amounts. This is the validation that "the normalization worked + the wallet model is self-consistent now."
+
+## Prerequisites
+
+- [ ] Issue 05 complete (migration 33 applied)
+- [ ] Issue 05 check #8 passed (no negative CHARGE_DEDUCT rows)
+
+## Why this approach over alternatives
+
+| Alternative | Reason rejected |
+|---|---|
+| Skip — trust that migration 33's `RAISE NOTICE` counts looked right | The notices show "this many rows changed" but don't prove "the resulting ledger sums to a non-negative balance per wallet." Different check. |
+| Write the validation as a one-off SQL query | The script exists, does the job, and emits structured output. Use it. |
+| Apply automatic fixes if drift found | The script is read-only by design. Any drift found is investigated case-by-case. Auto-fixing wallet balances is the kind of thing that loses customer money. |
+
+## What to do
+
+```bash
+# Single SSM-friendly command:
+sudo docker exec ocpp-backend-prod python scripts/reconcile_wallet_balance.py 2>&1 | tail -50
+```
+
+What the script outputs:
+- Per-wallet summary: wallet_id, current derived balance, TOP_UP sum, CHARGE_DEDUCT sum
+- Any wallets with negative derived balance (should be 0 wallets in steady state)
+- Any wallets with TOP_UP rows but no `payment_metadata.status = 'COMPLETED'` (PENDING rows that haven't credited yet — normal during the Razorpay confirmation window)
+- A summary line: total wallets checked, total flagged for review
+
+## Expected outcomes
+
+| Outcome | Meaning | Action |
+|---|---|---|
+| Zero anomalies, all wallets non-negative | Steady state ✅ | Done |
+| A few wallets with PENDING top-ups in flight | Normal — those payments haven't confirmed yet | Note for follow-up; recheck in 1 hour |
+| A few wallets with negative derived balance | Could be legit if a budget-cap dispatch failed (charger over-delivered energy). See CLAUDE.md wallet ledger section: "negative derived balance is observable, not impossible." | Investigate per-wallet. If small (under ~₹10), likely the normal "budget cap fail-safe" case. If large, real bug. |
+| Many wallets flagged | Migration 33 didn't normalize correctly | STOP — major issue. Compare against pre-deploy `pg_dump`. |
+
+## Verification
+
+The script's exit code is `0` if everything looks healthy. If it exits non-zero, the output should explain why.
+
+```bash
+sudo docker exec ocpp-backend-prod python scripts/reconcile_wallet_balance.py
+echo "Exit code: $?"
+```
+
+Optionally, sample-check the per-wallet sum manually:
+
+```bash
+DB_USER=$(grep ^DB_USER= /home/ec2-user/ocpp-server/.env.prod | cut -d= -f2-)
+DB_NAME=$(grep ^DB_NAME= /home/ec2-user/ocpp-server/.env.prod | cut -d= -f2-)
+
+# Pick a wallet with recent activity:
+sudo docker exec ocpp-postgres-prod psql -U "$DB_USER" -d "$DB_NAME" -x -c "
+  SELECT wallet_id,
+         SUM(CASE WHEN type='TOP_UP'
+                   AND (payment_metadata->>'status') = 'COMPLETED'
+                  THEN amount ELSE 0 END)
+         - SUM(CASE WHEN type='CHARGE_DEDUCT' THEN amount ELSE 0 END) AS derived_balance,
+         COUNT(*) AS total_rows
+  FROM wallet_transaction
+  WHERE wallet_id IN (SELECT wallet_id FROM wallet_transaction ORDER BY created_at DESC LIMIT 5)
+  GROUP BY wallet_id;
+"
+```
+
+## Definition of done
+
+- Script ran to completion
+- Exit code is 0 OR any non-zero exit's output has been reviewed and the flagged wallets explained (e.g. PENDING top-ups still in flight)
+- No "many wallets flagged" outcome (which would indicate migration 33 didn't normalize)
+- Output saved to a file (e.g. `/tmp/wallet-reconcile-2026-05-27.log`) for retrospective

--- a/.scratch/prod-deploy-2026-05/issues/09-post-deploy-smoke-tests.md
+++ b/.scratch/prod-deploy-2026-05/issues/09-post-deploy-smoke-tests.md
@@ -1,0 +1,118 @@
+Status: ready-for-human
+
+# Post-deploy smoke tests + 24-48h observation
+
+## What to build
+
+User-flow verification of the features that shipped in this deploy, plus a passive observation window watching Sentry, NR, and CloudWatch for emergent issues. **This is the final gate before declaring the deploy successful.**
+
+If serious issues surface here, refer back to issue 04's rollback section.
+
+## Prerequisites
+
+- [ ] Issues 04, 05, 06, 07, 08 all complete
+- [ ] Admin Clerk session available for testing
+- [ ] (Optional) Test charger available for E2E OCPP testing
+
+## What to test (in rough priority order)
+
+### A. Admin UI — basic feature sanity (~20 min)
+
+| Feature | What to verify | How |
+|---|---|---|
+| Chargers list | Loads, status pill renders, availability toggle responds | `/admin/chargers` — click a toggle, refresh, confirm flip |
+| Availability toggle on a real charger | OCPP message sent + `Charger.availability` persists | Click toggle; check `audit_log` for `charger.availability_changed`; verify `availability` column flipped |
+| Stuck settlements page | Loads, "Mark BELOW_THRESHOLD" + "Mark SETTLED" buttons render correctly | `/admin/settlements/stuck` — if any rows exist, eligibility check should match payout amount |
+| Franchisee detail page | Settlement Ledger table includes the new terminal-action buttons per row | `/admin/franchisees/<id>` — Settlement Ledger card |
+| Firmware page | Loads, list shows existing firmware, upload accepts a file | `/admin/firmware` — upload a small test binary |
+| GST invoices admin page | Loads, recent invoices render with new fields (place_of_supply_state_code, series, etc.) | `/admin/gst-filings` (or wherever invoices live) |
+
+### B. Customer-facing — non-destructive sanity (~10 min)
+
+| Feature | How |
+|---|---|
+| `/my-charges` loads (public, no auth) | Try with a known UPI VPA from prod |
+| Active session card renders (if there's a live charging session) | Same page with an active session |
+| QR scan + payment flow | DON'T trigger a real payment. Just verify the scanner page loads and a QR endpoint returns sensible JSON for a known charger |
+
+### C. Backend smoke tests (~10 min)
+
+```bash
+# OCPP traffic flowing
+sudo docker logs ocpp-backend-prod --since 5m 2>&1 | grep -iE "Heartbeat|StatusNotification|BootNotification" | wc -l
+# Expected: > 10 in 5 min (depends on charger count)
+
+# No spike of new errors since deploy
+sudo docker logs ocpp-backend-prod --since 30m 2>&1 | grep -iE "ERROR|FATAL|exception|traceback" | head -20
+# Expected: empty or only known-benign warnings
+
+# Sentry receiving events at production env
+# Check Sentry UI: production env should show a recent event timestamp
+# (Even if no errors, normal traces/logs land there with logging integration)
+
+# New Relic APM showing the new app
+# Check NR UI: "OCPP-Server-Production" should appear in APM & Services
+# Verify it's receiving transactions
+```
+
+### D. Migration-specific behavior verification (~15 min)
+
+For each major migration that shipped, verify the user-visible aspect:
+
+| Migration | What to check |
+|---|---|
+| 32 + 33 (wallet ledger) | Get a known customer's wallet balance via API, compare to manual SUM via psql — must match |
+| 27-30 (GST overhaul) | Most recent GST invoice has populated supplier_gstin, place_of_supply_state_code, gateway_charges fields |
+| 35 (firmware state machine v2) | Existing firmware updates page shows their state correctly (no orphan rows) |
+| 36 (tariff all-in column) | A tariff in the system shows `tariff_per_kwh_all_in` populated and `rate_per_kwh` ~2% lower than before |
+| 41 (drop qr_code unique) | Try creating a charger that previously would have hit a uniqueness conflict (or skip — additive change) |
+| 42 (availability column) | Per check A above — toggle reflects column, not status |
+
+### E. The OCPP E2E test (optional but recommended)
+
+If you have access to a real charger or simulator pointed at prod:
+
+1. Trigger a StartTransaction
+2. Send a few MeterValues frames
+3. Send a StopTransaction
+4. Verify:
+   - Transaction lands in DB with sensible energy + cost
+   - GST invoice is generated and uploaded to `voltlync-invoices-prod` S3 bucket
+   - Customer wallet was debited correctly (CHARGE_DEDUCT row with positive amount)
+   - The full ledger SUM matches the wallet balance shown in admin UI
+
+### F. The 24-48h passive observation
+
+For the next 24-48 hours, watch (no active polling required — set alerts):
+
+| Watch | Where |
+|---|---|
+| Sentry exception rate | Sentry "production" env — should be flat or trending down |
+| NR APM error rate | NR `OCPP-Server-Production` entity |
+| NR APM latency (p50/p95/p99) | Should be within ~10% of pre-deploy baseline (we don't have a clean baseline — but a 2x spike is a problem) |
+| CloudWatch RDS-equivalent: backend container CPU/memory | EC2 metrics — no spike vs pre-deploy |
+| Stuck-payout detector firing? | Sentry "Stuck franchisee payouts" alerts — should NOT fire for previously-stuck entries (we backfilled in issue 07) |
+| Wallet negative-balance custom metric | NR `Custom/Wallet/NegativeBalance` — should be ~0 events |
+| OCPP heartbeat rate | NR `Custom/OCPP/Messages/IN/Heartbeat` — steady |
+| Disk usage on prod EC2 | Should be flat (log rotation isn't enabled on staging-style anchor on prod — prod has per-service rotation already) |
+
+## Triggers for rollback
+
+ANY of the following → roll back per issue 04:
+
+- Backend won't stay up (`docker ps` shows restart-loop)
+- 5xx error rate on `/api/*` endpoints > 10% sustained
+- Migration corruption found (e.g. wallet sums diverging from reality)
+- GST invoices failing to generate for new sessions (legal/compliance)
+- A real customer-impacting incident attributable to the deploy
+
+If any single feature is broken but the system is otherwise healthy — log it as a follow-up bug, don't roll back the whole deploy.
+
+## Definition of done
+
+- All A + B + C + D checks pass
+- (Optional) E test passed against a real or simulated charger
+- Zero unexpected error spikes in F observation window over 24h
+- Stuck-payout detector has fired at least once without alerting on previously-stuck entries
+- Any follow-up bugs filed as separate issues
+- Operator sign-off: "deploy successful, no rollback needed"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,17 @@
 - **Docker build parity**: when changes touch the build (new imports, new deps, config), run `docker compose build frontend` / `docker compose build backend` locally to catch image-level failures before they hit staging.
 - Never declare a change "done" based only on `tsc` output or partial lint runs — staging/prod rebuilds enforce the full ruleset.
 
+## Logs
+
+Both compose files cap container log file growth so nothing fills the host's disk, but they do it differently:
+
+- **`docker-compose.staging.yml`** uses a single `x-default-logging` YAML anchor at the top and every service references it via `logging: *default-logging` — **5 × 50 MB = 250 MB** per container. Added 2026-05-27. New services should reference the same anchor.
+- **`docker-compose.prod.yml`** has per-service `logging:` blocks with deliberately different caps — backend gets the most room (20m × 5 = 100 MB), nginx/postgres/redis/frontend smaller (10m × 3 = 30 MB), certbot smallest (5m × 2 = 10 MB). These are tuned for actual write volume per service; don't unify them without reason.
+
+In either env, `docker logs` reads transparently across the rotated files. Don't ship a new service to either compose file without a `logging:` block.
+
+`make staging-logs` / `make prod-logs` (and the per-service variants) default to `--tail=100 -f` — last 100 lines for context, then live tail. For full history without follow, run `$(STAGING_COMPOSE) logs > staging.log` and grep the file.
+
 ## Wallet ledger pattern (CRITICAL — non-obvious from the code alone)
 
 The wallet is an **event-sourced ledger** post migrations 32 → 33 → 34. If you're touching `wallet_service.py`, `wallet_session_service.py`, `wallet_transaction`, or any code path that reads or writes a balance, read this:

--- a/Makefile
+++ b/Makefile
@@ -293,19 +293,20 @@ prod-nuke:
 	$(PROD_COMPOSE) down -v --rmi local
 	@echo "All containers, volumes, and images removed."
 
-# View production logs (all services)
+# View production logs — last 100 lines + live tail.
+# For full history pipe `$(PROD_COMPOSE) logs > prod.log` (no -f) and grep.
 prod-logs:
-	$(PROD_COMPOSE) logs -f
+	$(PROD_COMPOSE) logs --tail=100 -f
 
-# View specific service logs
+# View specific service logs — last 100 lines + live tail.
 prod-logs-backend:
-	$(PROD_COMPOSE) logs -f backend
+	$(PROD_COMPOSE) logs --tail=100 -f backend
 
 prod-logs-frontend:
-	$(PROD_COMPOSE) logs -f frontend
+	$(PROD_COMPOSE) logs --tail=100 -f frontend
 
 prod-logs-nginx:
-	$(PROD_COMPOSE) logs -f nginx
+	$(PROD_COMPOSE) logs --tail=100 -f nginx
 
 # Run migrations on production
 prod-migrate:
@@ -508,19 +509,20 @@ staging-nuke:
 	$(STAGING_COMPOSE) down -v --rmi local
 	@echo "All staging containers, volumes, and images removed."
 
-# View staging logs (all services)
+# View staging logs — last 100 lines + live tail.
+# For full history pipe `$(STAGING_COMPOSE) logs > staging.log` (no -f) and grep.
 staging-logs:
-	$(STAGING_COMPOSE) logs -f
+	$(STAGING_COMPOSE) logs --tail=100 -f
 
-# View specific service logs
+# View specific service logs — last 100 lines + live tail.
 staging-logs-backend:
-	$(STAGING_COMPOSE) logs -f backend
+	$(STAGING_COMPOSE) logs --tail=100 -f backend
 
 staging-logs-frontend:
-	$(STAGING_COMPOSE) logs -f frontend
+	$(STAGING_COMPOSE) logs --tail=100 -f frontend
 
 staging-logs-nginx:
-	$(STAGING_COMPOSE) logs -f nginx
+	$(STAGING_COMPOSE) logs --tail=100 -f nginx
 
 # Run migrations on staging
 staging-migrate:

--- a/backend/services/qr_payment_service.py
+++ b/backend/services/qr_payment_service.py
@@ -655,6 +655,18 @@ class QRPaymentService:
             return
 
         energy_kwh = transaction.energy_consumed_kwh or 0
+
+        # ADR 0002: zero-energy QR session must full-refund (amount_paid),
+        # not amount_paid - synthetic_platform_fee. The over-payment formula
+        # below is correct only when service was actually delivered. Route
+        # zero-energy cases to _full_refund so they hit the same path as the
+        # other "service not rendered" failures (RemoteStart fail, plug-in
+        # timeout, etc.) — `_full_refund` already handles the audit + the
+        # instant-refund speed=optimum amendment (ADR 0002, 2026-05-20).
+        if Decimal(str(energy_kwh)) <= 0:
+            await QRPaymentService._full_refund(qr_payment, "Zero energy delivered")
+            return
+
         tariff = await WalletService.get_applicable_tariff(qr_payment.charger_id)
         tariff_rate = tariff.rate_per_kwh if tariff else Decimal('0')
         gst_percent = tariff.gst_percent if tariff else Decimal('18')

--- a/backend/tests/test_qr_payment_service.py
+++ b/backend/tests/test_qr_payment_service.py
@@ -394,6 +394,61 @@ async def test_handle_charging_failure_issues_full_refund(client, qr_charger, qr
     assert await GSTInvoice.filter(transaction_id=txn.id).count() == 0
 
 
+@pytest.mark.asyncio
+async def test_process_qr_session_billing_zero_energy_issues_full_refund(
+    client, qr_charger, qr_code, qr_tariff, monkeypatch
+):
+    """ADR 0002: process_qr_session_billing must full-refund a zero-energy session.
+
+    Regression for the 2026-05-27 bug where the function fell through to the
+    over-payment formula `refund = amount_paid - energy_cost - gst - synth_fee`
+    when energy_consumed_kwh was 0. With energy=0 the formula returned
+    `amount_paid - synthetic_fee`, leaving the customer short by the synthetic
+    platform fee (~2%) when ADR 0002 promises a full refund.
+
+    Surfaced on payment id 96 (staging): ₹1500 paid, 0 kWh delivered, ₹1470
+    refunded — should have been ₹1500. This test routes a clean StopTransaction
+    with zero energy through process_qr_session_billing and asserts:
+      - the full amount_paid is refunded (no synthetic fee deduction)
+      - speed=optimum is requested (matches the _full_refund / ADR 0002 amendment)
+      - QR payment ends REFUNDED
+      - no GST invoice is issued (zero-energy = no taxable supply)
+    """
+    monkeypatch.setenv("RAZORPAY_INSTANT_REFUND_ENABLED", "true")
+
+    _, txn, qr_payment = await _make_qr_billing_fixture(
+        qr_charger, qr_code, qr_tariff, energy_consumed_kwh=0.0,
+    )
+
+    mock_razorpay = MagicMock()
+    mock_razorpay.refund_payment.return_value = {
+        "id": "rfnd_ZERO_ENERGY",
+        "speed_processed": "instant",
+    }
+
+    with patch("services.qr_payment_service.razorpay_service", mock_razorpay), \
+         patch("services.qr_payment_service.redis_manager") as mock_redis:
+        mock_redis.delete_qr_session = AsyncMock()
+        await QRPaymentService.process_qr_session_billing(txn.id)
+
+    mock_razorpay.refund_payment.assert_called_once()
+    call_kwargs = mock_razorpay.refund_payment.call_args.kwargs
+    # Full refund — not amount_paid - synthetic_fee.
+    assert call_kwargs["amount"] == Decimal("20.00")
+    # Routed through _full_refund → instant speed per ADR 0002 amendment.
+    assert call_kwargs["speed"] == "optimum"
+
+    await qr_payment.refresh_from_db()
+    assert qr_payment.refund_amount == Decimal("20.00")
+    assert qr_payment.status == QRPaymentStatusEnum.REFUNDED
+    # razorpay_refund_id populated proves _full_refund ran (not the over-payment path).
+    assert qr_payment.razorpay_refund_id == "rfnd_ZERO_ENERGY"
+
+    # No GST invoice for zero-energy sessions (ADR 0002 — no taxable supply).
+    from models import GSTInvoice
+    assert await GSTInvoice.filter(transaction_id=txn.id).count() == 0
+
+
 # ============================================================================
 # Razorpay instant refund speed wiring (ADR 0002)
 # ============================================================================

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -1,3 +1,12 @@
+# Cap each container's log file growth. 5 × 50 MB = 250 MB max per container
+# before the oldest file rotates out. `docker logs` still reads across the
+# rotated files transparently. Referenced from every service below.
+x-default-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "50m"
+    max-file: "5"
+
 services:
   # PostgreSQL Database
   postgres:
@@ -17,6 +26,7 @@ services:
     networks:
       - ocpp-network-staging
     restart: unless-stopped
+    logging: *default-logging
     deploy:
       resources:
         limits:
@@ -41,6 +51,7 @@ services:
     networks:
       - ocpp-network-staging
     restart: unless-stopped
+    logging: *default-logging
     deploy:
       resources:
         limits:
@@ -156,6 +167,7 @@ services:
     networks:
       - ocpp-network-staging
     restart: unless-stopped
+    logging: *default-logging
     deploy:
       resources:
         limits:
@@ -199,6 +211,7 @@ services:
     networks:
       - ocpp-network-staging
     restart: unless-stopped
+    logging: *default-logging
     deploy:
       resources:
         limits:
@@ -235,6 +248,7 @@ services:
     networks:
       - ocpp-network-staging
     restart: unless-stopped
+    logging: *default-logging
 
   # Certbot for SSL certificate management
   certbot:
@@ -247,6 +261,7 @@ services:
     networks:
       - ocpp-network-staging
     restart: unless-stopped
+    logging: *default-logging
 
 volumes:
   postgres_data_staging:


### PR DESCRIPTION
## Summary

- Add log rotation to `docker-compose.staging.yml` via a `x-default-logging` YAML anchor (250 MB cap per container)
- Change `make {staging,prod}-logs*` defaults from full-history-then-follow to `--tail=100 -f`
- Document the staging/prod log-rotation asymmetry in `CLAUDE.md`

Prod compose was already configured per-service with deliberately tuned caps (backend 100 MB, others 30 MB, certbot 10 MB) and is **not changed**.

## Why

1. **Disk-fill risk on staging.** No `logging:` config meant Docker's json-file driver grew unbounded between deploys. Current backend rate is ~3-4 MB/hour; a single noisy bug could fill the host's 13 GB free disk in days.
2. **`make staging-logs` UX.** The default was `docker compose logs -f`, which prints the entire container history before tailing live — typically thousands of lines right after a deploy. The 99% use case is "I want to watch what's happening now."

## Test plan

- [x] `docker compose -f docker-compose.staging.yml --env-file .env.staging.example config --quiet` → OK
- [x] `docker compose -f docker-compose.prod.yml --env-file .env.prod.example config --quiet` → OK (prod unchanged)
- [x] 6 `logging: *default-logging` refs in staging compose match all 6 services
- [x] All `make {staging,prod}-logs*` targets use `--tail=100 -f`
- [ ] After staging deploy, run `make staging-logs` — confirm it shows last 100 lines + live tail (not the full history)
- [ ] After staging deploy, write enough log volume to trigger a single rotation event — confirm `docker logs` still shows continuous output across the rotation boundary

## Rollback

Single-commit revert. No data or runtime state depends on this change — only the disk-write pattern of future log lines and the shape of the Makefile log targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)